### PR TITLE
Fix issue with overwrite / passthrough of onSerialize

### DIFF
--- a/src_web/comfyui/rgthree.ts
+++ b/src_web/comfyui/rgthree.ts
@@ -162,7 +162,7 @@ class Rgthree extends EventTarget {
     const onSerialize = (graph as any).onSerialize;
     (graph as any).onSerialize = (data: any) => {
       this.initialGraphToPromptSerializedWorkflowBecauseComfyUIBrokeStuff = data;
-      onSerialize?.apply(graph, data);
+      onSerialize?.call(graph, data);
     };
 
     // [🤮] Copying to clipboard clones nodes and then manipulats the linking data manually which

--- a/web/comfyui/rgthree.js
+++ b/web/comfyui/rgthree.js
@@ -96,7 +96,7 @@ class Rgthree extends EventTarget {
         const onSerialize = graph.onSerialize;
         graph.onSerialize = (data) => {
             this.initialGraphToPromptSerializedWorkflowBecauseComfyUIBrokeStuff = data;
-            onSerialize === null || onSerialize === void 0 ? void 0 : onSerialize.apply(graph, data);
+            onSerialize === null || onSerialize === void 0 ? void 0 : onSerialize.call(graph, data);
         };
         const copyToClipboard = LGraphCanvas.prototype.copyToClipboard;
         LGraphCanvas.prototype.copyToClipboard = function (nodes) {


### PR DESCRIPTION
Ran into issue when implementing personal tweak to comfy.

The `data` object returned from litegraph's `onSerialize` seems to be an Object. (litegraph.core.js ~2150) (in `LGraph.prototype.serialize`)

`somefn.apply()` expects an array as the second parameter.
Any downstream implementations will receive undefined. (at least I did, if this is on me, then feel free to close).

This PR changes the `apply` to a `call` (alternatively `data` could be changed to [data])