### PR TITLE
Allows building on Windows

### DIFF
--- a/__build__.py
+++ b/__build__.py
@@ -44,7 +44,7 @@ copytree(DIR_SRC_WEB, DIR_WEB, ignore=ignore_patterns("typings*", "*.ts", "*.scs
 log_step(status="Done")
 
 log_step(msg='TypeScript')
-checked = subprocess.run(["./node_modules/typescript/bin/tsc"], check=True)
+checked = subprocess.run(["node", "./node_modules/typescript/bin/tsc"], check=True)
 log_step(status="Done")
 
 scsss = glob(os.path.join(DIR_SRC_WEB, "**", "*.scss"), recursive=True)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "sass": "^1.70.0"
   },
   "scripts": {
-    "build": "./__build__.py"
+    "build": "./__build__.py || python .\\__build__.py"
   }
 }


### PR DESCRIPTION
Small tweaks to the build commands to allow it to work on Windows (since it doesn't support hashbang directives)

This would mean I can stop stashing/applying/stashing these tweaks 🙏 