### PR TITLE
[WIP] Add LORA_STACK input/output to Power Lora Loader

### DIFF
--- a/py/power_lora_loader.py
+++ b/py/power_lora_loader.py
@@ -12,13 +12,15 @@ class RgthreePowerLoraLoader:
 
   @classmethod
   def INPUT_TYPES(cls):  # pylint: disable = invalid-name, missing-function-docstring
+    optional: dict = FlexibleOptionalInputType(any_type)
+    optional.update({"lora_stack": ("LORA_STACK", {"default": None}),})
     return {
       "required": {
         "model": ("MODEL",),
         "clip": ("CLIP",),
       },
       # Since we will pass any number of loras in from the UI, this needs to always allow an
-      "optional": FlexibleOptionalInputType(any_type),
+      "optional": optional,
       "hidden": {},
     }
 
@@ -28,7 +30,8 @@ class RgthreePowerLoraLoader:
 
   def load_loras(self, model, clip, **kwargs):
     """Loops over the provided loras in kwargs and applies valid ones."""
-    lora_stack = list()
+    # Grab the stack if provided
+    lora_stack = kwargs.get("lora_stack", list())
     for key, value in kwargs.items():
       key = key.upper()
       if key.startswith('LORA_') and 'on' in value and 'lora' in value and 'strength' in value:
@@ -40,7 +43,13 @@ class RgthreePowerLoraLoader:
         if value['on'] and (strength_model != 0 or strength_clip != 0):
           lora = get_lora_by_filename(value['lora'], log_node=self.NAME)
           if lora is not None:
-            model, clip = LoraLoader().load_lora(model, clip, lora, strength_model, strength_clip)
             lora_stack.extend([(lora, strength_model, strength_clip)])
+
+    # Apply the accumulated LoRAs to the provided model
+    # This would be a place to fork to say:
+    # - only apply the LoRA in this node
+    # - apply the ones here and in the stack
+    for lora, strength_model, strength_clip in lora_stack:
+        model, clip = LoraLoader().load_lora(model, clip, lora, strength_model, strength_clip)
 
     return (model, clip, lora_stack)

--- a/py/power_lora_loader.py
+++ b/py/power_lora_loader.py
@@ -22,12 +22,13 @@ class RgthreePowerLoraLoader:
       "hidden": {},
     }
 
-  RETURN_TYPES = ("MODEL", "CLIP")
-  RETURN_NAMES = ("MODEL", "CLIP")
+  RETURN_TYPES = ("MODEL", "CLIP", "LORA_STACK")
+  RETURN_NAMES = ("MODEL", "CLIP", "LORA_STACK")
   FUNCTION = "load_loras"
 
   def load_loras(self, model, clip, **kwargs):
     """Loops over the provided loras in kwargs and applies valid ones."""
+    lora_stack = list()
     for key, value in kwargs.items():
       key = key.upper()
       if key.startswith('LORA_') and 'on' in value and 'lora' in value and 'strength' in value:
@@ -40,5 +41,6 @@ class RgthreePowerLoraLoader:
           lora = get_lora_by_filename(value['lora'], log_node=self.NAME)
           if lora is not None:
             model, clip = LoraLoader().load_lora(model, clip, lora, strength_model, strength_clip)
+            lora_stack.extend([(lora, strength_model, strength_clip)])
 
-    return (model, clip)
+    return (model, clip, lora_stack)

--- a/py/power_prompt_utils.py
+++ b/py/power_prompt_utils.py
@@ -33,7 +33,7 @@ def get_and_strip_loras(prompt, silent=False, log_node="Power Prompt"):
 
 # pylint: disable = too-many-return-statements, too-many-branches
 def get_lora_by_filename(file_path, lora_paths=None, log_node=None):
-  """Returns a lora by filename, looking for exactl paths and then fuzzier matching."""
+  """Returns a lora by filename, looking for exact paths and then fuzzier matching."""
   lora_paths = lora_paths if lora_paths is not None else folder_paths.get_filename_list('loras')
 
   if file_path in lora_paths:


### PR DESCRIPTION
# What?
Adds a secondary output to Power Lora Loader in the `LORA_STACK` format. Also takes _in_ a lora_stack to allow for chaining

## Why?
I have a multi-phase workflow that I want to share some common LoRAs but then augment them with others without having to clone nodes or keep them updated. I like the Power Lora Loader better than the Efficiency Nodes' LoRA Stacker.

@rgthree I could also break this into a separate `Power Lora Stacker (rgthree)` node. Or setup a property to allow for either/or (I figure just hiding the input/output nodes?)

> [!NOTE]
> There is an issue with this implementation when all of the outputs and inputs are chained.
> LoRAs are applied in each node, leading to weird results.
> I put together a test workflow: [Power_Lora_Loader_Stack_Test.json](https://github.com/user-attachments/files/15995832/Power_Lora_Loader_Stack_Test.json)
> (Open in a text-editor and Find/Replace `<<<CHECKPOINT>>>`, `<<<LORA_1>>>`, `<<<LORA_2>>>` for convenience)
