### PR TITLE
Hold Shift to keep picking LoRAs

### DIFF
--- a/src_web/comfyui/menu_auto_nest.ts
+++ b/src_web/comfyui/menu_auto_nest.ts
@@ -100,7 +100,7 @@ app.registerExtension({
           parentMenu: ContextMenu | undefined,
           node: LGraphNode,
         ) => {
-          oldCallback?.(item?.rgthree_originalValue!, options, event, undefined, node);
+          return oldCallback?.(item?.rgthree_originalValue!, options, event, undefined, node);
         };
         const [n, v] = logger.infoParts(`Nested folders found (${foldersCount}).`);
         console[n]?.(...v);

--- a/src_web/comfyui/power_lora_loader.ts
+++ b/src_web/comfyui/power_lora_loader.ts
@@ -10,6 +10,7 @@ import type {
   SerializedLGraphNode,
   Vector2,
   AdjustedMouseEvent,
+  IContextMenuOptions,
 } from "typings/litegraph.js";
 import type { ComfyObjectInfo, ComfyNodeConstructor } from "typings/comfy.js";
 import { RgthreeBaseServerNode } from "./base_node.js";
@@ -149,7 +150,7 @@ class RgthreePowerLoraLoader extends RgthreeBaseServerNode {
         "➕ Add Lora",
         (event: AdjustedMouseEvent, pos: Vector2, node: TLGraphNode) => {
           rgthreeApi.getLoras().then(loras => {
-            showLoraChooser(event as PointerEvent, (value: ContextMenuItem|string) => {
+            showLoraChooser(event as PointerEvent, (value: ContextMenuItem|string, _options: IContextMenuOptions, leafEvent: MouseEvent) => {
               if (typeof value === "string") {
                 if (value.includes('Power Lora Chooser')) {
                   // new RgthreePowerLoraChooserDialog().show();
@@ -161,6 +162,8 @@ class RgthreePowerLoraLoader extends RgthreeBaseServerNode {
                   this.setDirtyCanvas(true, true);
                 }
               }
+              // If true (Shift held down), keeps the context menu open to allow for selecting multiple LoRAs
+              return leafEvent.shiftKey;
             // }, null, ["⚡️ Power Lora Chooser", ...loras]);
             }, null, [...loras]);
           });

--- a/web/comfyui/menu_auto_nest.js
+++ b/web/comfyui/menu_auto_nest.js
@@ -70,7 +70,7 @@ app.registerExtension({
                 const oldCallback = options.rgthree_originalCallback;
                 options.callback = undefined;
                 const newCallback = (item, options, event, parentMenu, node) => {
-                    oldCallback === null || oldCallback === void 0 ? void 0 : oldCallback(item === null || item === void 0 ? void 0 : item.rgthree_originalValue, options, event, undefined, node);
+                    return oldCallback === null || oldCallback === void 0 ? void 0 : oldCallback(item === null || item === void 0 ? void 0 : item.rgthree_originalValue, options, event, undefined, node);
                 };
                 const [n, v] = logger.infoParts(`Nested folders found (${foldersCount}).`);
                 (_d = console[n]) === null || _d === void 0 ? void 0 : _d.call(console, ...v);

--- a/web/comfyui/power_lora_loader.js
+++ b/web/comfyui/power_lora_loader.js
@@ -69,7 +69,7 @@ class RgthreePowerLoraLoader extends RgthreeBaseServerNode {
         this.widgetButtonSpacer = this.addCustomWidget(new RgthreeDividerWidget({ marginTop: 4, marginBottom: 0, thickness: 0 }));
         this.addCustomWidget(new RgthreeBetterButtonWidget("➕ Add Lora", (event, pos, node) => {
             rgthreeApi.getLoras().then(loras => {
-                showLoraChooser(event, (value) => {
+                showLoraChooser(event, (value, _options, leafEvent) => {
                     var _b;
                     if (typeof value === "string") {
                         if (value.includes('Power Lora Chooser')) {
@@ -82,6 +82,7 @@ class RgthreePowerLoraLoader extends RgthreeBaseServerNode {
                             this.setDirtyCanvas(true, true);
                         }
                     }
+                    return leafEvent.shiftKey;
                 }, null, [...loras]);
             });
             return true;


### PR DESCRIPTION
Have a lot of LoRAs to add at once? Are they "organized" in a labyrinthine tree of folders that I swear at one point I knew what I was doing alright there was definitely a reason and it totally made sense and I'm not wrong and I'm not mad and I remember where I was going with this...

Anyway -- With this PR, if you're adding LoRAs to the Power Lora Loader, holding shift keeps the context menu from closing so you can add several at a time.