### PR TITLE
[Power Lora Loader] Add context menu option to fetch all Civitai data

### DIFF
--- a/src_web/comfyui/power_lora_loader.ts
+++ b/src_web/comfyui/power_lora_loader.ts
@@ -10,6 +10,8 @@ import type {
   SerializedLGraphNode,
   Vector2,
   AdjustedMouseEvent,
+  IContextMenuOptions,
+  ContextMenu,
 } from "typings/litegraph.js";
 import type { ComfyObjectInfo, ComfyNodeConstructor } from "typings/comfy.js";
 import { RgthreeBaseServerNode } from "./base_node.js";
@@ -114,6 +116,32 @@ class RgthreePowerLoraLoader extends RgthreeBaseServerNode {
     this.size[0] = Math.max(this.size[0], computed[0]);
     this.size[1] = Math.max(this.size[1], computed[1]);
     this.setDirtyCanvas(true, true);
+  }
+
+  override getExtraMenuOptions(canvas: LGraphCanvas, options: ContextMenuItem[]): void {
+    super.getExtraMenuOptions?.apply(this, [...arguments] as any);
+    const fetchInfoMenuItem = {
+      content: "Fetch info for all LoRAs",
+      callback: (
+        _value: ContextMenuItem,
+        _options: IContextMenuOptions,
+        _event: MouseEvent,
+        _parentMenu: ContextMenu | undefined,
+        _node: TLGraphNode,
+      ) => {
+        const loraWidgets: PowerLoraLoaderWidget[] = this.widgets
+          .filter((widget): widget is PowerLoraLoaderWidget => widget instanceof PowerLoraLoaderWidget);
+        const refreshPromises = loraWidgets
+          .map(widget => widget.value.lora)
+          .filter((file): file is string => file !== null)
+          .map((file) => MODEL_INFO_SERVICE.refreshLora(file));
+          Promise.all(refreshPromises).then((loraInfo) => {
+            // Silently succeeds or fails. Probably want a better notification than `alert`
+            // alert(`LoRA info refreshed. ${loraInfo.length} checked`);
+          });
+      },
+    };
+    options.splice(options.length - 1, 0, fetchInfoMenuItem);
   }
 
   /** Adds a new lora widget in the proper slot. */

--- a/web/comfyui/power_lora_loader.js
+++ b/web/comfyui/power_lora_loader.js
@@ -53,6 +53,24 @@ class RgthreePowerLoraLoader extends RgthreeBaseServerNode {
         this.size[1] = Math.max(this.size[1], computed[1]);
         this.setDirtyCanvas(true, true);
     }
+    getExtraMenuOptions(canvas, options) {
+        var _b;
+        (_b = super.getExtraMenuOptions) === null || _b === void 0 ? void 0 : _b.apply(this, [...arguments]);
+        const fetchInfoMenuItem = {
+            content: "Fetch info for all LoRAs",
+            callback: (_value, _options, _event, _parentMenu, _node) => {
+                const loraWidgets = this.widgets
+                    .filter((widget) => widget instanceof PowerLoraLoaderWidget);
+                const refreshPromises = loraWidgets
+                    .map(widget => widget.value.lora)
+                    .filter((file) => file !== null)
+                    .map((file) => MODEL_INFO_SERVICE.refreshLora(file));
+                Promise.all(refreshPromises).then((loraInfo) => {
+                });
+            },
+        };
+        options.splice(options.length - 1, 0, fetchInfoMenuItem);
+    }
     addNewLoraWidget(lora) {
         this.loraWidgetsCounter++;
         const widget = this.addCustomWidget(new PowerLoraLoaderWidget("lora_" + this.loraWidgetsCounter));


### PR DESCRIPTION
## Why?
I don't like having to open the info dialog and fetch each time.

## Notes
I could also expose a "Force" option, but that feels like it might be too much.

Do you think this should go under the rgthree submenu?