### PR TITLE
Add configuration option for Power Prompts to bypass stabilizeInputsOutputs() 

### DIFF
--- a/py/config.py
+++ b/py/config.py
@@ -52,6 +52,9 @@ DEFAULT_CONFIG = get_rgthree_default_config()
 if 'progress_bar' not in DEFAULT_CONFIG["features"]:
   DEFAULT_CONFIG["features"]["progress_bar"] = {"enabled": False}
 
+if 'do_clip_model_input_validation_check' not in DEFAULT_CONFIG["features"]:
+  DEFAULT_CONFIG["features"]["clip_model_input_validation_check"] = {"enabled": True}
+
 USER_CONFIG = get_rgthree_user_config()
 
 # Migrate old config options into "features"

--- a/rgthree_config.json.default
+++ b/rgthree_config.json.default
@@ -33,6 +33,9 @@
     // entry in case it causes issues. This is only for the nodeCreated event/function as of now.
     "invoke_extensions_async": {
       "node_created": true
+    },
+    "do_clip_model_input_validation_check": {
+      "enabled": true
     }
   },
   "nodes": {

--- a/src_web/comfyui/base_power_prompt.ts
+++ b/src_web/comfyui/base_power_prompt.ts
@@ -9,6 +9,7 @@ import type {LLink, IComboWidget, LGraphNode as TLGraphNode, LiteGraph as TLiteG
 import type {ComfyObjectInfo, ComfyGraphNode} from 'typings/comfy.js';
 import { wait } from "rgthree/common/shared_utils.js";
 import { rgthree } from "./rgthree.js";
+import { SERVICE as CONFIG_SERVICE } from "./config_service.js";
 
 declare const LiteGraph: typeof TLiteGraph;
 declare const LGraphNode: typeof TLGraphNode;
@@ -23,6 +24,7 @@ export class PowerPrompt {
   readonly combos: {[key:string]: IComboWidget} = {};
   readonly combosValues: {[key:string]: string[]} = {};
   boundOnFreshNodeDefs!: (event: CustomEvent) => void;
+  doInputValidation: boolean = CONFIG_SERVICE.getConfigValue("features.do_clip_model_input_validation_check.enabled", true);
 
   private configuring = false;
 
@@ -110,6 +112,11 @@ export class PowerPrompt {
     const clipLinked = this.node.inputs.some(i=>i.name.includes('clip') && !!i.link);
     const modelLinked = this.node.inputs.some(i=>i.name.includes('model') && !!i.link);
     for (const output of this.node.outputs) {
+      // If input validation is disabled by config we should return all outputs are enabled
+      if (!this.doInputValidation) {
+        output.disabled = false;
+        continue;
+      }
       const type = (output.type as string).toLowerCase();
       if (type.includes('model')) {
         output.disabled = !modelLinked;

--- a/src_web/comfyui/config.ts
+++ b/src_web/comfyui/config.ts
@@ -167,6 +167,16 @@ const CONFIGURABLE: { features: ConfigurationSchema[] } = {
         "event on some rgthree-comfy nodes. Now it's possible and this option is only here in " +
         "for easy if something is wrong.",
     },
+    {
+      key: "features.do_clip_model_input_validation_check.enabled",
+      type: ConfigType.BOOLEAN,
+      label: "Power Prompt input checking",
+      isDevOnly: false,
+      description:
+        "Recommended to leave this enabled unles you are experiencing conflicts with other custom nodes" +
+        "e.g the Anything Everywhere nodes which connect nodes in ways not detected by our validation" +
+        "Setting to false will make model/prompt/clip outputs always available"
+    },
   ],
 };
 

--- a/web/comfyui/base_power_prompt.js
+++ b/web/comfyui/base_power_prompt.js
@@ -1,10 +1,12 @@
 import { api } from '../../scripts/api.js';
 import { wait } from "../../rgthree/common/shared_utils.js";
 import { rgthree } from "./rgthree.js";
+import { SERVICE as CONFIG_SERVICE } from "./config_service.js";
 export class PowerPrompt {
     constructor(node, nodeData) {
         this.combos = {};
         this.combosValues = {};
+        this.doInputValidation = CONFIG_SERVICE.getConfigValue("features.do_clip_model_input_validation_check.enabled", true);
         this.configuring = false;
         this.node = node;
         this.node.properties = this.node.properties || {};
@@ -68,6 +70,10 @@ export class PowerPrompt {
         const clipLinked = this.node.inputs.some(i => i.name.includes('clip') && !!i.link);
         const modelLinked = this.node.inputs.some(i => i.name.includes('model') && !!i.link);
         for (const output of this.node.outputs) {
+            if (!this.doInputValidation) {
+                output.disabled = false;
+                continue;
+            }
             const type = output.type.toLowerCase();
             if (type.includes('model')) {
                 output.disabled = !modelLinked;

--- a/web/comfyui/config.js
+++ b/web/comfyui/config.js
@@ -141,6 +141,15 @@ const CONFIGURABLE = {
                 "event on some rgthree-comfy nodes. Now it's possible and this option is only here in " +
                 "for easy if something is wrong.",
         },
+        {
+            key: "features.do_clip_model_input_validation_check.enabled",
+            type: ConfigType.BOOLEAN,
+            label: "Power Prompt input checking",
+            isDevOnly: false,
+            description: "Recommended to leave this enabled unles you are experiencing conflicts with other custom nodes" +
+                "e.g the Anything Everywhere nodes which connect nodes in ways not detected by our validation" +
+                "Setting to false will make model/prompt/clip outputs always available"
+        },
     ],
 };
 function fieldrow(item) {


### PR DESCRIPTION
I've been doing lots of editing my workflows and I consistently run into the issue that I cannot connect conditioning/model outputs from the Power Prompt nodes when the model/clip inputs are attached via Anything Everywhere nodes. I'm not sure what is going on in code that is causing these connections to not be treated as connected nodes, something to do with how Anything Everywhere broadcasting works I assume, but I did not wish to dig into so much code to resolve it. Instead I offer this configuration settings to bypass the problem with balancing behavior that occurs due to this incompatibility.