### PR TITLE
Fix inserting workflow that contain reroutes

### DIFF
--- a/src_web/comfyui/reroute.ts
+++ b/src_web/comfyui/reroute.ts
@@ -457,6 +457,10 @@ class RerouteNode extends RgthreeBaseVirtualNode {
     _link_info: LLink,
     _ioSlot: INodeOutputSlot | INodeInputSlot,
   ) {
+    if (app.configuringGraph) {
+      return
+    }
+
     // Prevent multiple connections to different types when we have no input
     if (connected && type === LiteGraph.OUTPUT) {
       // Ignore wildcard nodes as these will be updated to real types

--- a/src_web/typings/comfy.d.ts
+++ b/src_web/typings/comfy.d.ts
@@ -30,6 +30,7 @@ export interface ComfyApp {
 	}
 	// Just marking as any for now.
 	menu?: any;
+	configuringGraph: boolean;
 }
 
 export interface ComfyWidget extends IWidget {


### PR DESCRIPTION
This PR fixes inserting workflows that contain reroutes. "Inserting" refers to the below feature:

![Selection_685](https://github.com/user-attachments/assets/4e5eb4df-6756-452e-b0db-165b6efad19c)

The same issue and same fix occurred in ComfyUI_frontend [here](https://github.com/Comfy-Org/ComfyUI_frontend/pull/2008)


To reproduce issue:

1. save a workflow containing a reroute
2. close the workflow
3. attempt to insert the workflow into another workflow that does not have a reroute

---

Note: `onConnectionsChanged` is still called on the reroutes immediately after the graph is done configuring, allowing for normal setup. This PR prevents a premature invocation which does not happen when the graph is loaded the normal way.