### PR TITLE
[Fix] Get Model Info local image url for non-lora models

### DIFF
--- a/py/server/utils_info.py
+++ b/py/server/utils_info.py
@@ -81,7 +81,7 @@ async def get_model_info(file: str,
     should_save = True
 
   if img_next_to_file:
-    img_next_to_file_url = f'/rgthree/api/loras/img?file={file}'
+    img_next_to_file_url = f'/rgthree/api/{model_type}/img?file={file}'
     if len(info_data['images']) == 0 or info_data['images'][0]['url'] != img_next_to_file_url:
       info_data['images'].insert(0, {'url': img_next_to_file_url})
       should_save = True


### PR DESCRIPTION
If you make request to retrieve model info, that is not lora, first image link always will be created as if model is lora, but, it wouldn't work for checkpoints, unet, upscalers, etc.