### PR TITLE
fix fast-groups toggle + widget sync in frontend (fast_actions/fast_groups_muter)

### DIFF
--- a/web/comfyui/fast_groups_muter.js
+++ b/web/comfyui/fast_groups_muter.js
@@ -180,6 +180,18 @@ export class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
     }
     async handleAction(action) {
         var _a, _b, _c, _d, _e;
+        // Helper: some widgets (FastGroupsToggleRowWidget) expose boolean state as widget.toggled
+        // while others might use widget.value. Normalize to a boolean.
+        const getWidgetBool = (widget) => {
+            try {
+                if (typeof widget.toggled !== "undefined") {
+                    return !!widget.toggled;
+                }
+            }
+            catch (e) { /* ignore */ }
+            return !!widget.value;
+        };
+
         if (action === "Mute all" || action === "Bypass all") {
             const alwaysOne = ((_a = this.properties) === null || _a === void 0 ? void 0 : _a[PROPERTY_RESTRICTION]) === "always one";
             for (const [index, widget] of this.widgets.entries()) {
@@ -196,7 +208,9 @@ export class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
             const onlyOne = (_c = this.properties) === null || _c === void 0 ? void 0 : _c[PROPERTY_RESTRICTION].includes(" one");
             let foundOne = false;
             for (const [index, widget] of this.widgets.entries()) {
-                let newValue = onlyOne && foundOne ? false : !widget.value;
+                // use normalized boolean state
+                const current = getWidgetBool(widget);
+                let newValue = onlyOne && foundOne ? false : !current;
                 foundOne = foundOne || newValue;
                 widget === null || widget === void 0 ? void 0 : widget.doModeChange(newValue, true);
             }


### PR DESCRIPTION
Summary
-------
This PR fixes a frontend bug in the RGTHREE custom nodes where the "Fast Actions" button and the "Fast Groups" widgets would not reliably toggle group enable/bypass state (the button seemed to toggle only once or behave directionally). The issue was caused by a mix of:
 - reading widget boolean state from `widget.value` (an object) instead of the `FastGroupsToggleRowWidget` boolean accessor `widget.toggled`,
 - and not always letting nodes handle their own action via `handleAction`, which can lead to stale UI widget state unless a recompute/refresh is run afterwards.

Changes
-------------
- Normalize widget boolean reads (use `widget.toggled` if present, fallback to `widget.value`) in `fast_groups_muter.js`.
- Prefer calling `node.handleAction(action)` from the Fast Actions button if the node implements it. After calling `handleAction`, force a widget refresh and schedule the fast-groups service recompute to ensure UI state and internal group caches are synchronized.

Files changed
-------------
- custom_nodes/rgthree-comfy/web/comfyui/fast_groups_muter.js
- custom_nodes/rgthree-comfy/web/comfyui/fast_actions_button.js

Testing
-------
- Manual: Verified locally that Toggle/Enable/Bypass now flips groups back-and-forth reliably with `toggleRestriction = "always one"`.
See gif animation of the button working on latest comfyui version as of today 

![brave_GKbr9RIbdK](https://github.com/user-attachments/assets/286e2f89-2553-4d5c-9d86-2f921e7ebf8f)
