### PR TITLE
puter: Implement correct short-circuit evaluation for Boolean operati…

### DIFF
--- a/py/power_puter.py
+++ b/py/power_puter.py
@@ -468,11 +468,17 @@ class _Puter:
 
     if isinstance(stmt, ast.BoolOp):
       left = self._eval_statement(stmt.values[0], ctx=ctx)
-      # If we're an AND and already false, then don't even evaluate the right.
-      if isinstance(stmt.op, ast.And) and not left:
-        return left
-      right = self._eval_statement(stmt.values[1], ctx=ctx)
-      return _OPERATORS[type(stmt.op)](left, right)
+      # Implement Python short-circuit semantics and return actual operand values.
+      if isinstance(stmt.op, ast.And):
+        if not left:
+          return left
+        right = self._eval_statement(stmt.values[1], ctx=ctx)
+        return right
+      elif isinstance(stmt.op, ast.Or):
+        if left:
+          return left
+        right = self._eval_statement(stmt.values[1], ctx=ctx)
+        return right
 
     if isinstance(stmt, ast.UnaryOp):
       return _OPERATORS[type(stmt.op)](self._eval_statement(stmt.operand, ctx=ctx))


### PR DESCRIPTION
…ons in `_eval_statement`.

## Issue
```py
3 or 4
```
returns `1` instead of expected `3`.

## Cause
A binary operator evaluation thing.  Was fine for boolean conditionals (`if 3 or 4`) but when `or` was used to mean _this or **that** if not this_, not so much.

## Why I care?
It broke my lambda test.

```py
_ = a      # underscore
def accumulate(iterable):
    return tuple(_.reduce(
        iterable,
        lambda acc, x, *args: (acc.append((acc[-1] if acc else 0) + x) or acc),
        []
    ))
```




