### PR TITLE
build.py: updated path normalization for `.js` files [windows]

### DIFF
--- a/__build__.py
+++ b/__build__.py
@@ -115,7 +115,7 @@ def build(without_tests = True, fix = False):
   log_step(msg='Cleaning Imports')
   js_files = glob(os.path.join(DIR_WEB, '**', '*.js'), recursive=True)
   for file in js_files:
-    rel_path = file.replace(f'{DIR_WEB}/', "")
+    rel_path = os.path.relpath(file, DIR_WEB)
     with open(file, 'r', encoding="utf-8") as f:
       filedata = f.read()
     num = rel_path.count(os.sep)


### PR DESCRIPTION
This is the one-line fix for the issue with building on Windows.  The one that created `../../../../../../../../app.js` paths. 

```
-   rel_path = file.replace(f'{DIR_WEB}/', "")
+   rel_path = os.path.relpath(file, DIR_WEB)
```

This avoids the excessive changes in #609.

The declarations in comfy/frontend do still need to be made exportable, but there is probably a more appropriate place to deal with that.