### PR TITLE
bookmarks: long-press to set

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ Note, you can right-click on a bunch of the rgthree-comfy nodes and select `🛟
 >    </details>
 
 ## Bookmark (🔖)
-> Place the bookmark node anywhere on screen to quickly navigate to that with a shortcut key.
+> Place the bookmark node anywhere on screen to quickly navigate to it with a shortcut — and set it with a long‑press, just like saving a station on your car radio.
 > <details>
 >    <summary>ℹ️ <i>See More Information</i></summary>
 >
 >    - Define the `shortcut_key` to press to go right to that bookmark node, anchored in the top left.
 >    - You can also define the zoom level as well!
+>    - Quick press: Jump to the bookmark.
+>    - Press and hold: Hold the same shortcut for ~1 second to set/update the bookmark to your current viewport and zoom (must be on the same graph).
 >    - Pro tip: `shortcut_key` can be multiple keys. For instance "alt + shift + !" would require
 >      pressing the alt key, the shift key, and the "!" (as in the "1" key, but with shift pressed)
 >      in order to trigger.
@@ -101,7 +103,7 @@ Note, you can right-click on a bunch of the rgthree-comfy nodes and select `🛟
 >      - `image_b` _Optional._ The second image to use to compare. Optional only if image_a is a batch with two images.
 >    - **Properties:** You can change the following properties (by right-clicking on the node, and select "Properties" or "Properties Panel" from the menu):
 >      - `comparer_mode` - Choose between "Slide" and "Click". Defaults to "Slide".
-
+>    </details>
 
 ## Image Inset Crop
 > The node that lets you crop an input image by either pixel value, or percentage value.

--- a/src_web/comfyui/bookmark.ts
+++ b/src_web/comfyui/bookmark.ts
@@ -28,7 +28,7 @@ export class Bookmark extends RgthreeBaseVirtualNode {
   // counteract it's computeSize calculation by offsetting the start.
   static slot_start_y = -20;
 
-  // LiteGraph adds mroe spacing than we want when calculating a nodes' `_collapsed_width`, so we'll
+  // LiteGraph adds more spacing than we want when calculating a nodes' `_collapsed_width`, so we'll
   // override it with a setter and re-set it measured exactly as we want.
   ___collapsed_width: number = 0;
 
@@ -50,6 +50,11 @@ export class Bookmark extends RgthreeBaseVirtualNode {
   }
 
   readonly keypressBound;
+  readonly keyupBound;
+
+  private longPressTimer: any = null;
+  private longPressTriggered: boolean = false;
+  private pendingShortcut: boolean = false;
 
   constructor(title = Bookmark.title) {
     super(title);
@@ -72,6 +77,7 @@ export class Bookmark extends RgthreeBaseVirtualNode {
       precision: 2,
     });
     this.keypressBound = this.onKeypress.bind(this);
+    this.keyupBound = this.onKeyup.bind(this);
     this.title = "🔖";
     this.onConstructed();
   }
@@ -88,10 +94,20 @@ export class Bookmark extends RgthreeBaseVirtualNode {
 
   override onAdded(graph: LGraph): void {
     KEY_EVENT_SERVICE.addEventListener("keydown", this.keypressBound as EventListener);
+    KEY_EVENT_SERVICE.addEventListener("keyup", this.keyupBound as EventListener);
   }
 
   override onRemoved(): void {
     KEY_EVENT_SERVICE.removeEventListener("keydown", this.keypressBound as EventListener);
+    KEY_EVENT_SERVICE.removeEventListener("keyup", this.keyupBound as EventListener);
+    this.clearLongPressTimer();
+  }
+
+  private clearLongPressTimer() {
+    if (this.longPressTimer) {
+      clearTimeout(this.longPressTimer);
+      this.longPressTimer = null;
+    }
   }
 
   onKeypress(event: CustomEvent<{originalEvent: KeyboardEvent}>) {
@@ -103,9 +119,46 @@ export class Bookmark extends RgthreeBaseVirtualNode {
 
     // Only the shortcut keys are held down, optionally including "shift".
     if (KEY_EVENT_SERVICE.areOnlyKeysDown(this.widgets[0]!.value as string, true)) {
-      this.canvasToBookmark();
+      // Start tracking a potential long-press. Only set bookmark when on the current visible graph.
+      this.pendingShortcut = true;
+      this.longPressTriggered = false;
+
+      // Always prevent default once we recognize the shortcut sequence.
       originalEvent.preventDefault();
       originalEvent.stopPropagation();
+
+      if (!this.longPressTimer) {
+        this.longPressTimer = setTimeout(() => {
+          this.longPressTimer = null;
+          // Ensure keys are still held and we're on the current graph before setting.
+          if (KEY_EVENT_SERVICE.areOnlyKeysDown(this.widgets[0]!.value as string, true)
+              && this.graph === (app.canvas as LGraphCanvas).getCurrentGraph()) {
+            this.setBookmarkFromCanvas();
+            this.longPressTriggered = true;
+            this.pendingShortcut = false;
+          }
+        }, 1000);
+      }
+    }
+  }
+
+  onKeyup(event: CustomEvent<{originalEvent: KeyboardEvent}>) {
+    const originalEvent = event.detail.originalEvent;
+    const target = (originalEvent.target as HTMLElement)!;
+    if (getClosestOrSelf(target, 'input,textarea,[contenteditable="true"]')) {
+      return;
+    }
+
+    // If we were pending and long-press did not trigger, treat as a tap: recall bookmark.
+    if (this.pendingShortcut) {
+      this.clearLongPressTimer();
+      if (!this.longPressTriggered) {
+        this.canvasToBookmark();
+        originalEvent.preventDefault();
+        originalEvent.stopPropagation();
+      }
+      this.pendingShortcut = false;
+      this.longPressTriggered = false;
     }
   }
 
@@ -142,6 +195,26 @@ export class Bookmark extends RgthreeBaseVirtualNode {
     }
     if (canvas?.ds?.scale != null) {
       canvas.ds.scale = Number(this.widgets[1]!.value || 1);
+    }
+    canvas.setDirty(true, true);
+  }
+
+  /** Sets this bookmark's position and zoom based on the current canvas viewport. */
+  setBookmarkFromCanvas() {
+    const canvas = app.canvas as LGraphCanvas;
+    // Only set when our node is in the current graph.
+    if (this.graph !== canvas.getCurrentGraph()) return;
+    const offset = canvas?.ds?.offset;
+    if (offset) {
+      // Inverse of canvasToBookmark padding logic.
+      this.pos[0] = -offset[0] + 16;
+      this.pos[1] = -offset[1] + 40;
+    }
+    if (canvas?.ds?.scale != null) {
+      // store zoom in widget index 1
+      if (this.widgets && this.widgets[1]) {
+        this.widgets[1]!.value = Number(canvas.ds.scale || 1);
+      }
     }
     canvas.setDirty(true, true);
   }


### PR DESCRIPTION
Adds long‑press behavior to rgthree Bookmarks. A quick press on the bookmark’s shortcut recalls it; pressing and holding the same shortcut for ~1s sets/updates the bookmark to the current viewport and zoom -- just like saving a preset on a car radio.