### PR TITLE
sfink-bookmark-clone-unique-shortcut: Improve rgthree-comfy

### DIFF
--- a/src_web/comfyui/bookmark.ts
+++ b/src_web/comfyui/bookmark.ts
@@ -76,6 +76,26 @@ export class Bookmark extends RgthreeBaseVirtualNode {
     this.onConstructed();
   }
 
+  /**
+   * Override clone for, at the least, deep-copying properties.
+   */
+  override clone() {
+    const cloned = super.clone()!;
+    try {
+      // If the cloned bookmark's shortcut is already in use, assign the next available one.
+      const existing = BOOKMARKS_SERVICE.getExistingShortcuts();
+      const current = (cloned.widgets?.[0]?.value as string)?.toLowerCase?.() ?? "";
+      if (!current || existing.has(current)) {
+        const next = BOOKMARKS_SERVICE.getNextShortcut();
+        if (cloned.widgets?.[0]) {
+          cloned.widgets[0].value = next;
+        }
+      }
+    } catch (e) {
+      // No-op: in case services are unavailable during clone in some contexts.
+    }
+    return cloned;
+  }
   // override computeSize(out?: Vector2 | undefined): Vector2 {
   //   super.computeSize(out);
   //   const minHeight = (this.widgets?.length || 0) * (LiteGraph.NODE_WIDGET_HEIGHT + 4) + 16;
@@ -85,6 +105,7 @@ export class Bookmark extends RgthreeBaseVirtualNode {
   get shortcutKey(): string {
     return (this.widgets[0]?.value as string)?.toLocaleLowerCase() ?? "";
   }
+
 
   override onAdded(graph: LGraph): void {
     KEY_EVENT_SERVICE.addEventListener("keydown", this.keypressBound as EventListener);

--- a/web/comfyui/bookmark.js
+++ b/web/comfyui/bookmark.js
@@ -39,6 +39,23 @@ export class Bookmark extends RgthreeBaseVirtualNode {
         this.title = "🔖";
         this.onConstructed();
     }
+    clone() {
+        var _a, _b, _c, _d, _e, _f;
+        const cloned = super.clone();
+        try {
+            const existing = BOOKMARKS_SERVICE.getExistingShortcuts();
+            const current = (_e = (_d = (_c = (_b = (_a = cloned.widgets) === null || _a === void 0 ? void 0 : _a[0]) === null || _b === void 0 ? void 0 : _b.value) === null || _c === void 0 ? void 0 : _c.toLowerCase) === null || _d === void 0 ? void 0 : _d.call(_c)) !== null && _e !== void 0 ? _e : "";
+            if (!current || existing.has(current)) {
+                const next = BOOKMARKS_SERVICE.getNextShortcut();
+                if ((_f = cloned.widgets) === null || _f === void 0 ? void 0 : _f[0]) {
+                    cloned.widgets[0].value = next;
+                }
+            }
+        }
+        catch (e) {
+        }
+        return cloned;
+    }
     get shortcutKey() {
         var _a, _b, _c;
         return (_c = (_b = (_a = this.widgets[0]) === null || _a === void 0 ? void 0 : _a.value) === null || _b === void 0 ? void 0 : _b.toLocaleLowerCase()) !== null && _c !== void 0 ? _c : "";


### PR DESCRIPTION
This pull request was created by an automated script.

Summary:
- Base: upstream/main
- Head: sfink-bookmark-clone-unique-shortcut

Commits included in this PR:
ed5d629 when bookmark is cloned, set unique shortcut (Christopher Anderson, 2025-11-10)

Files changed:
- __build__.py (+1/-1)
- package-lock.json (+4/-4)
- package.json (+1/-1)
- pnpm-lock.yaml (+0/-507)
- py/server/rgthree_server.py (+1/-1)
- pyproject.toml (+1/-1)
- src_web/comfyui/bookmark.ts (+176/-163)
- src_web/comfyui/comfy_ui_bar.ts (+31/-175)
- src_web/comfyui/dynamic_context_base.ts (+3/-4)
- src_web/comfyui/power_puter.ts (+1/-0)
- src_web/comfyui/rgthree.ts (+7/-9)
- src_web/comfyui/utils.ts (+15/-36)
- src_web/comfyui/utils_deprecated_comfyui.ts (+15/-11)
- src_web/comfyui/utils_widgets.ts (+1/-9)
- src_web/common/css/buttons.scss (+3/-53)
- src_web/common/css/menu.scss (+38/-52)
- src_web/scripts_comfy/ui/components/button.ts (+23/-0)
- src_web/scripts_comfy/ui/components/buttonGroup.ts (+10/-0)
- src_web/scripts_comfy/ui/components/popup.ts (+16/-0)
- src_web/typings/litegraph.d.ts (+3/-89)
- web/comfyui/bookmark.js (+18/-4)
- web/comfyui/comfy_ui_bar.js (+27/-124)
- web/comfyui/dynamic_context_base.js (+1/-4)
- web/comfyui/rgthree.css (+14/-66)
- web/comfyui/rgthree.js (+4/-5)
- web/comfyui/utils.js (+17/-21)
- web/comfyui/utils_deprecated_comfyui.js (+4/-7)
- web/common/css/buttons.css (+2/-42)
- web/common/css/menu.css (+12/-24)

Total additions: +449, deletions: -1413

Note: This is a test of automated pull request generation.