### PR TITLE
handle escaped \\n and semi-escaped \\\n

### DIFF
--- a/web/comfyui/label.js
+++ b/web/comfyui/label.js
@@ -30,7 +30,9 @@ export class Label extends RgthreeBaseVirtualNode {
         const backgroundColor = this.properties["backgroundColor"] || "";
         ctx.font = `${Math.max(this.properties["fontSize"] || 0, 1)}px ${(_a = this.properties["fontFamily"]) !== null && _a !== void 0 ? _a : "Arial"}`;
         const padding = (_b = Number(this.properties["padding"])) !== null && _b !== void 0 ? _b : 0;
-        const processedTitle = ((_c = this.title) !== null && _c !== void 0 ? _c : "").replace(/\\n/g, "\n").replace(/\n*$/, "");
+        const processedTitle = ((_c = this.title) !== null && _c !== void 0 ? _c : "")
+            .replace(/\\+n/g, (m) => "\\".repeat((m.length - 1) >> 1) + (((m.length - 1) % 2) ? "\n" : "n"))
+            .replace(/\n*$/, "");
         const lines = processedTitle.split("\n");
         const maxWidth = Math.max(...lines.map((s) => ctx.measureText(s).width));
         this.size[0] = maxWidth + padding * 2;


### PR DESCRIPTION
An appendum to the previous label.ts PR #608 to allow `\n`.

It allows for escaping.

<img width="612" height="195" alt="image" src="https://github.com/user-attachments/assets/66161482-09b1-4ab0-87d9-3e70fcd44642" />
