### PR TITLE
Power Puter: add Civitai filter for Lora triggers

### DIFF
--- a/py/power_lora_loader.py
+++ b/py/power_lora_loader.py
@@ -77,7 +77,7 @@ class RgthreePowerLoraLoader:
     return result
 
   @classmethod
-  def get_enabled_triggers_from_prompt_node(cls, prompt_node: dict, max_each: int = 1):
+  def get_enabled_triggers_from_prompt_node(cls, prompt_node: dict, civitai: bool = False, max_each: int = 1):
     """Gets trigger words up to the max for enabled loras of a node within a server prompt."""
     loras = [l['name'] for l in cls.get_enabled_loras_from_prompt_node(prompt_node)]
     trained_words = []
@@ -97,5 +97,8 @@ class RgthreePowerLoraLoader:
           'civitai or manually added words?'
         )
         continue
-      trained_words += [w for wi in info['trainedWords'][:max_each] if (wi and (w := wi['word']))]
+      if civitai:
+        trained_words += [w for wi in info['trainedWords'][:max_each] if wi and wi.get('civitai') is True and (w := wi['word'])]
+      else:
+        trained_words += [w for wi in info['trainedWords'][:max_each] if (wi and (w := wi['word']))]
     return trained_words


### PR DESCRIPTION
Added optional `civitai` parameter to `get_enabled_triggers_from_prompt_node()` method in Power Lora Loader to filter trigger words by their source.

### Changes

**File: `py/power_lora_loader.py`**

- Added optional `civitai: bool = False` parameter to `get_enabled_triggers_from_prompt_node()`
- When `civitai=True`, the method now filters trigger words to only include those with `"civitai": true` in the model info JSON
- When `civitai=False` (default), all trigger words are returned as before

### Usage in Power Puter node

```python
# Get all trigger words (default behavior)
triggers(max_each = None)

# Get only CivitAI-sourced trigger words
triggers(max_each = None, civitai = True)
```

### Example Model Info JSON

```json
{
  "trainedWords": [
    {
      "word": "some_trigger_word",
      "count": 42,
      "metadata": true
    },
    {
      "word": "high_detail",
      "count": 42,
      "metadata": true,
      "civitai": true
    }
  ]
}
```

With `civitai=True`, only `"high_detail"` would be returned; with default behavior, both words would be returned.

This change allows users to selectively include only trigger words that were fetched from CivitAI, which can be useful for filtering out manually added or less reliable trigger words.