### PR TITLE
Fix SDXL Power Prompt NoneType conditioning by adding .execute() fallback

### DIFF
--- a/py/sdxl_power_prompt_postive.py
+++ b/py/sdxl_power_prompt_postive.py
@@ -157,11 +157,17 @@ class RgthreeSDXLPowerPromptPositive:
         crop_width = crop_width if crop_width and crop_width > 0 else 0
         crop_height = crop_height if crop_height and crop_height > 0 else 0
         try:
-          conditioning = CLIPTextEncodeSDXL().encode(opt_clip, opt_clip_width, opt_clip_height,
-                                                     crop_width, crop_height, target_width,
-                                                     target_height, prompt_g, prompt_l)[0]
+          sdxl_node = CLIPTextEncodeSDXL()
+          if hasattr(sdxl_node, 'encode'):
+            conditioning = sdxl_node.encode(opt_clip, opt_clip_width, opt_clip_height,
+                                            crop_width, crop_height, target_width,
+                                            target_height, prompt_g, prompt_l)[0]
+          else:
+            conditioning = sdxl_node.execute(opt_clip, opt_clip_width, opt_clip_height,
+                                             crop_width, crop_height, target_width,
+                                             target_height, prompt_g, prompt_l)[0]
         except Exception:
-          do_regular_clip_text_encode = True
+          do_regular_clip_text_encode = False
           log_node_info(
             self.NAME,
             'Exception while attempting to CLIPTextEncodeSDXL, will fall back to standard encoding.'


### PR DESCRIPTION
Fixes #707 

DISCLAIMER: Asked Gemini to write this, then edited for conciseness. I've verified the fix working with the latest comfyui master branch, not older ones.

This code checks for the new .encode API if it's available on the node, otherwise it utilizes the new .execute() method.

# Problem
Recent versions of ComfyUI have migrated core nodes like CLIPTextEncodeSDXL to a new internal API. This change removed the .encode() method and replaced it with .execute().

The current RgthreeSDXLPowerPromptPositive implementation specifically calls .encode(), which fails in the new API. Furthermore, a logic bug in the except block was setting do_regular_clip_text_encode = True upon failure, which incorrectly told the node that the encoding succeeded. This caused the node to skip the standard fallback and return None for conditioning, crashing the entire workflow.