### PR TITLE
Power Puter: guard against None extra_pnginfo in /prompt API mode

### DIFF
--- a/py/power_puter.py
+++ b/py/power_puter.py
@@ -330,7 +330,7 @@ class RgthreePowerPuter:
     code = kwargs['code']
     unique_id = kwargs['unique_id']
     pnginfo = kwargs['extra_pnginfo']
-    workflow = pnginfo["workflow"] if "workflow" in pnginfo else {"nodes": []}
+    workflow = pnginfo["workflow"] if pnginfo and "workflow" in pnginfo else {"nodes": []}
     prompt = kwargs['prompt']
     dynprompt = kwargs['dynprompt']
 


### PR DESCRIPTION
Fixes a TypeError: argument of type 'NoneType' is not iterable that occurs when using Power Puter via the ComfyUI /prompt API, where extra_pnginfo is not passed and defaults to None.