### PR TITLE
fix: Power Puter outputs widget — Nodes 2.0 (Vue renderer) compatibility

### DIFF
--- a/src_web/comfyui/power_puter.ts
+++ b/src_web/comfyui/power_puter.ts
@@ -71,6 +71,14 @@ class RgthreePowerPuter extends RgthreeBaseServerNode {
     removeUnusedInputsFromEnd(this, 1);
     this.addAnyInput();
     this.setOutputs();
+    // In the Vue renderer (Nodes 2.0), the mini-canvas widget only redraws
+    // via triggerDraw (not the continuous LiteGraph repaint loop), and
+    // output slot property mutations (type, name, label) on the shallowReactive
+    // outputs array are not tracked.  Trigger both explicitly.
+    this.outputTypeWidget?.triggerDraw?.();
+    if (this.outputs?.length) {
+      this.outputs.splice(0, this.outputs.length, ...this.outputs);
+    }
   }
 
   private addInitialWidgets() {
@@ -107,6 +115,7 @@ class RgthreePowerPuter extends RgthreeBaseServerNode {
       const outputLabel =
         output.label === "*" || output.label === output.type ? null : output.label;
       output.type = String(desired);
+      output.name = outputLabel || output.type;
       output.label = outputLabel || output.type;
     }
   }

--- a/src_web/comfyui/utils_widgets.ts
+++ b/src_web/comfyui/utils_widgets.ts
@@ -169,11 +169,15 @@ export abstract class RgthreeBaseWidget<V extends ICustomWidget["value"]> implem
         }
         part.wasMouseClickedAndIsOver = false;
       }
+      // Skip bounds re-check for onClick handlers: they were already validated
+      // on pointerdown when added to downedHitAreasForClick.  In the Vue
+      // renderer (Nodes 2.0), WidgetLegacy wraps custom widgets in a
+      // mini-canvas and the pointerup coordinates arrive in node-local space
+      // (offset by title bar + widgets above) instead of mini-canvas-local
+      // space, so a re-check here would always fail.
       for (const part of this.downedHitAreasForClick) {
-        if (this.clickWasWithinBounds(pos, part.bounds)) {
-          const thisHandled = part.onClick!.apply(this, [event, pos, node, part]);
-          anyHandled = anyHandled || thisHandled == true;
-        }
+        const thisHandled = part.onClick!.apply(this, [event, pos, node, part]);
+        anyHandled = anyHandled || thisHandled == true;
       }
       this.downedHitAreasForClick.length = 0;
       if (wasMouseDownedAndOver) {

--- a/web/comfyui/power_puter.js
+++ b/web/comfyui/power_puter.js
@@ -28,9 +28,14 @@ class RgthreePowerPuter extends RgthreeBaseServerNode {
         return debounce(this.stabilizeBound, ms);
     }
     stabilize() {
+        var _a, _b;
         removeUnusedInputsFromEnd(this, 1);
         this.addAnyInput();
         this.setOutputs();
+        (_b = (_a = this.outputTypeWidget) === null || _a === void 0 ? void 0 : _a.triggerDraw) === null || _b === void 0 ? void 0 : _b.call(_a);
+        if (this.outputs && this.outputs.length) {
+            this.outputs.splice(0, this.outputs.length, ...this.outputs);
+        }
     }
     addInitialWidgets() {
         if (!this.outputTypeWidget) {
@@ -56,6 +61,7 @@ class RgthreePowerPuter extends RgthreeBaseServerNode {
             output = output || this.addOutput("", "");
             const outputLabel = output.label === "*" || output.label === output.type ? null : output.label;
             output.type = String(desired);
+            output.name = outputLabel || output.type;
             output.label = outputLabel || output.type;
         }
     }

--- a/web/comfyui/utils_widgets.js
+++ b/web/comfyui/utils_widgets.js
@@ -85,10 +85,8 @@ export class RgthreeBaseWidget {
                 part.wasMouseClickedAndIsOver = false;
             }
             for (const part of this.downedHitAreasForClick) {
-                if (this.clickWasWithinBounds(pos, part.bounds)) {
-                    const thisHandled = part.onClick.apply(this, [event, pos, node, part]);
-                    anyHandled = anyHandled || thisHandled == true;
-                }
+                const thisHandled = part.onClick.apply(this, [event, pos, node, part]);
+                anyHandled = anyHandled || thisHandled == true;
             }
             this.downedHitAreasForClick.length = 0;
             if (wasMouseDownedAndOver) {


### PR DESCRIPTION
## Problem

The Power Puter's custom OutputsWidget (output type chips + "+" button) is completely
non-functional in the Nodes 2.0 Vue renderer:

1. **Clicks don't register** — clicking chips or the "+" button does nothing
2. **Widget doesn't redraw** after adding/removing/changing outputs
3. **Output port labels are missing** — dots appear but without type labels (FLOAT, INT, etc.)

All three work correctly in the legacy LiteGraph renderer.

## Root Cause

**Click handling** (`utils_widgets.ts`): `WidgetLegacy.vue` wraps custom widgets in a
mini-canvas. On `pointerdown`, coordinates are mini-canvas-local (correct), so `hitArea`
bounds matching works and handlers are queued in `downedHitAreasForClick`. On `pointerup`,
coordinates arrive in node-local space (offset by title bar + widgets above) via
`CanvasPointer.finally` in `processWidgetClick`. The bounds re-check on `pointerup` always
fails because the coordinate systems don't match.

**Widget redraw** (`power_puter.ts`): LiteGraph continuously repaints the canvas, so
`draw()` is called every frame. The Vue renderer only calls `draw()` when
`widget.triggerDraw()` is invoked. After `stabilize()` modifies the outputs, nothing
triggers a redraw.

**Output labels** (`power_puter.ts`): `addOutput("", "")` creates slots with `name=""`.
`setOutputs()` sets `type` and `label` but not `name`. Vue's `OutputSlot.vue` hides the
label text when `name === ""` (via `hasNoLabel` computed). In LiteGraph, the canvas renderer
falls through to `label` for display, so this was never noticed.

## Fix

**`utils_widgets.ts`** — Remove `pointerup` bounds re-check for `onClick` handlers. The
`downedHitAreasForClick` array is only populated during `pointerdown` after a successful
bounds check. Re-validating on `pointerup` is redundant (and broken in Vue mode). This is
safe in LiteGraph mode — minor UX change where a click fires even if the cursor drifts
slightly between down and up, which is standard button behavior.

**`power_puter.ts`** — `stabilize()`: Added `triggerDraw()` call to refresh the mini-canvas
widget, and an outputs array splice to poke Vue's `shallowReactive` proxy so output slot
components re-render with updated properties.

**`power_puter.ts`** — `setOutputs()`: Added `output.name = outputLabel || output.type`
alongside the existing `label` assignment so Vue's `OutputSlot` displays the type label.

## Known Limitation

When the "Workflow Overview" sidebar panel is open, it binds to the same widget and
overwrites `triggerDraw` (single-slot design in `WidgetLegacy.vue`). The node's mini-canvas
won't update until the sidebar is closed or the node is resized. This is a ComfyUI frontend
architectural limitation, not something fixable from the extension side.

## Testing

- **Nodes 2.0 ON:** chips clickable, context menus appear, add/remove/change outputs works,
  output port labels show correctly
- **Nodes 2.0 OFF:** no behavior change from current main