### PR TITLE
Add Sorting to BaseFastGroupsModeChanger

### DIFF
--- a/src_web/comfyui/fast_groups_muter.ts
+++ b/src_web/comfyui/fast_groups_muter.ts
@@ -24,6 +24,10 @@ const PROPERTY_MATCH_TITLE = "matchTitle";
 const PROPERTY_SHOW_NAV = "showNav";
 const PROPERTY_SHOW_ALL_GRAPHS = "showAllGraphs";
 const PROPERTY_RESTRICTION = "toggleRestriction";
+const PROPERTY_MANUAL_ORDER = "manualOrder";
+
+// Sentinel sort value engaged automatically the first time a user drags a row.
+const SORT_MANUAL = "manual";
 
 /**
  * Fast Muter implementation that looks for groups in the workflow and adds toggles to mute them.
@@ -51,9 +55,10 @@ export abstract class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
   static "@showAllGraphs" = {type: "boolean"};
   static "@sort" = {
     type: "combo",
-    values: ["position", "alphanumeric", "custom alphabet"],
+    values: ["position", "alphanumeric", "custom alphabet", "manual"],
   };
   static "@customSortAlphabet" = {type: "string"};
+  static "@manualOrder" = {type: "array"};
 
   override properties!: RgthreeBaseVirtualNode["properties"] & {
     [PROPERTY_MATCH_COLORS]: string;
@@ -63,6 +68,7 @@ export abstract class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
     [PROPERTY_SORT]: string;
     [PROPERTY_SORT_CUSTOM_ALPHA]: string;
     [PROPERTY_RESTRICTION]: string;
+    [PROPERTY_MANUAL_ORDER]: string[];
   };
 
   static "@toggleRestriction" = {
@@ -79,7 +85,13 @@ export abstract class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
     this.properties[PROPERTY_SORT] = "position";
     this.properties[PROPERTY_SORT_CUSTOM_ALPHA] = "";
     this.properties[PROPERTY_RESTRICTION] = "default";
+    this.properties[PROPERTY_MANUAL_ORDER] = [];
   }
+
+  // Transient drag state, written by the dragging row widget's hit-area handlers and read by
+  // draw() to render the moving row + drop indicator. Not serialized.
+  dragWidget: FastGroupsToggleRowWidget | null = null;
+  dragDropIndex: number = -1;
 
   override onConstructed(): boolean {
     this.addOutput("OPT_CONNECTION", "*");
@@ -141,6 +153,23 @@ export abstract class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
           return 1;
         }
         return a.title.localeCompare(b.title);
+      });
+    }
+
+    // Manual drag order. Reapplied on every refresh cycle so the service's polling
+    // doesn't revert a user's drag. Groups absent from the saved order (e.g. newly
+    // created) keep their incoming order and fall to the end.
+    if (sort === SORT_MANUAL) {
+      const order: string[] = this.properties?.[PROPERTY_MANUAL_ORDER] || [];
+      const rank = new Map<string, number>();
+      order.forEach((title, i) => rank.set(title, i));
+      groups.sort((a, b) => {
+        const ai = rank.has(a.title) ? rank.get(a.title)! : Number.MAX_SAFE_INTEGER;
+        const bi = rank.has(b.title) ? rank.get(b.title)! : Number.MAX_SAFE_INTEGER;
+        if (ai === bi) {
+          return 0; // preserve incoming order for unranked / equal
+        }
+        return ai - bi;
       });
     }
 
@@ -251,6 +280,44 @@ export abstract class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
     return size;
   }
 
+  /**
+   * Returns the row widgets in display order. Non-row widgets (none expected) are ignored so
+   * drag math stays correct.
+   */
+  getRowWidgets(): FastGroupsToggleRowWidget[] {
+    return (this.widgets || []).filter(
+      (w): w is FastGroupsToggleRowWidget => w instanceof FastGroupsToggleRowWidget,
+    );
+  }
+
+  /**
+   * Moves the row widget at `from` to index `to`, persists the resulting order, and engages the
+   * "manual" sort mode. Called by a row widget when the user finishes a drag-to-reorder.
+   */
+  commitManualOrder(from: number, to: number) {
+    const rows = this.getRowWidgets();
+    to = Math.max(0, Math.min(rows.length - 1, to));
+    if (from < 0 || from >= rows.length || from === to) {
+      this.setDirtyCanvas(true, false);
+      return;
+    }
+
+    // Reorder a copy of the row widgets, then write the new sequence back into this.widgets,
+    // preserving the slots of any non-row widgets (none expected, but safe).
+    rows.splice(to, 0, rows.splice(from, 1)[0]!);
+    let r = 0;
+    for (let i = 0; i < this.widgets.length; i++) {
+      if (this.widgets[i] instanceof FastGroupsToggleRowWidget) {
+        this.widgets[i] = rows[r++]!;
+      }
+    }
+
+    // Engage manual sort and persist the order (group titles) with the workflow.
+    this.properties[PROPERTY_SORT] = SORT_MANUAL;
+    this.properties[PROPERTY_MANUAL_ORDER] = rows.map((w) => w.group.title);
+    this.setDirtyCanvas(true, true);
+  }
+
   override async handleAction(action: string) {
     if (action === "Mute all" || action === "Bypass all") {
       const alwaysOne = this.properties?.[PROPERTY_RESTRICTION] === "always one";
@@ -311,7 +378,14 @@ export abstract class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
             </p></li>
             <li><p>
               <code>${PROPERTY_SORT}</code> - Sort the toggles' order by "alphanumeric", graph
-              "position", or "custom alphabet". <i>(default: "position")</i>
+              "position", "custom alphabet", or "manual". <i>(default: "position")</i>
+            </p>
+            <p>
+              <strong>Manual drag ordering:</strong> drag any row by its label (the left part of
+              the row, away from the toggle and nav arrow) and drop it in a new position. The first
+              drag automatically switches <code>${PROPERTY_SORT}</code> to "manual", and the order
+              is saved with your workflow. Newly-added groups appear at the end until you place
+              them.
             </p></li>
             <li>
               <p>
@@ -387,10 +461,25 @@ class FastGroupsToggleRowWidget extends RgthreeBaseWidget<{toggled: boolean}> {
   group: LGraphGroup;
   node: BaseFastGroupsModeChanger;
 
+  // Drag-to-reorder state, local to this widget while it is the one being dragged.
+  private dragging = false;
+  private dragStartY = 0;
+  private dragStartIndex = -1;
+
   constructor(group: LGraphGroup, node: BaseFastGroupsModeChanger) {
     super("RGTHREE_TOGGLE_AND_NAV");
     this.group = group;
     this.node = node;
+    // Hit areas dispatched by RgthreeBaseWidget.mouse(). Bounds are recomputed in draw() so
+    // they track the node's current width. Each is [xStart, width] (full row height).
+    this.hitAreas = {
+      // The label/grip region on the left: start a drag-to-reorder here.
+      drag: {bounds: [0, 0], onDown: this.onDragDown, onMove: this.onDragMove, onUp: this.onDragUp},
+      // The toggle in the middle-right: flip this group on click.
+      toggle: {bounds: [0, 0], onClick: this.onToggleClick},
+      // The nav arrow on the far right: jump to the group.
+      nav: {bounds: [0, 0], onClick: this.onNavClick},
+    };
   }
 
   doModeChange(force?: boolean, skipOtherNodeCheck?: boolean) {
@@ -437,9 +526,28 @@ class FastGroupsToggleRowWidget extends RgthreeBaseWidget<{toggled: boolean}> {
     posY: number,
     height: number,
   ) {
+    const fastNode = node as unknown as BaseFastGroupsModeChanger;
+    const isDragging = fastNode.dragWidget === this;
+
+    // While dragging this row, dim it slightly to signal it's being moved.
+    if (isDragging) {
+      ctx.save();
+      ctx.globalAlpha = 0.4;
+    }
+
     const widgetData = drawNodeWidget(ctx, {size: [width, height], pos: [15, posY]});
 
     const showNav = node.properties?.[PROPERTY_SHOW_NAV] !== false;
+
+    // Recompute hit-area X bounds for the current width. Bounds are [xStart, width].
+    // Layout (right to left): nav arrow (~28px) | toggle + on/off label (~90px) | label/drag.
+    const navWidth = 28 + 1;
+    const navStart = width - 15 - navWidth;
+    const toggleWidth = 90;
+    const toggleStart = navStart - toggleWidth;
+    this.hitAreas.nav!.bounds = showNav ? [navStart, navWidth] : [width, 0];
+    this.hitAreas.toggle!.bounds = [toggleStart, showNav ? toggleWidth : toggleWidth + navWidth];
+    this.hitAreas.drag!.bounds = [15, Math.max(0, toggleStart - 15)];
 
     // Render from right to left, since the text on left will take available space.
     // `currentX` markes the current x position moving backwards.
@@ -489,12 +597,50 @@ class FastGroupsToggleRowWidget extends RgthreeBaseWidget<{toggled: boolean}> {
       currentX -= 7;
       ctx.textAlign = "left";
       let maxLabelWidth = widgetData.width - widgetData.margin - 10 - (widgetData.width - currentX);
+      const labelX = widgetData.margin + 10 + 10; // +10 to clear the grip handle
       if (label != null) {
         ctx.fillText(
-          fitString(ctx, label, maxLabelWidth),
-          widgetData.margin + 10,
+          fitString(ctx, label, maxLabelWidth - 10),
+          labelX,
           posY + height * 0.7,
         );
+      }
+
+      // Drag grip: three small dots at the far left, hinting the row is draggable.
+      const gripX = widgetData.margin + 6;
+      const gripMidY = posY + height * 0.5;
+      ctx.fillStyle = widgetData.colorTextSecondary;
+      for (let i = -1; i <= 1; i++) {
+        ctx.beginPath();
+        ctx.arc(gripX, gripMidY + i * 4, 1.1, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+
+    if (isDragging) {
+      ctx.restore();
+    }
+
+    // Drop indicator: when this row is the current drop target during a drag, draw a line
+    // at its top edge so the user sees where the dragged row will land.
+    const fastNode2 = node as unknown as BaseFastGroupsModeChanger;
+    if (
+      fastNode2.dragWidget &&
+      fastNode2.dragWidget !== this &&
+      fastNode2.dragDropIndex > -1
+    ) {
+      const rows = (node.widgets || []).filter(
+        (w) => w instanceof FastGroupsToggleRowWidget,
+      );
+      if (rows[fastNode2.dragDropIndex] === this) {
+        ctx.save();
+        ctx.strokeStyle = "#89A";
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(widgetData.margin, posY - 1);
+        ctx.lineTo(widgetData.width - widgetData.margin, posY - 1);
+        ctx.stroke();
+        ctx.restore();
       }
     }
   }
@@ -503,30 +649,80 @@ class FastGroupsToggleRowWidget extends RgthreeBaseWidget<{toggled: boolean}> {
     return this.value;
   }
 
-  override mouse(event: CanvasMouseEvent, pos: Vector2, node: LGraphNode): boolean {
-    if (event.type == "pointerdown") {
-      if (node.properties?.[PROPERTY_SHOW_NAV] !== false && pos[0] >= node.size[0] - 15 - 28 - 1) {
-        const canvas = app.canvas as TLGraphCanvas;
-        const lowQuality = (canvas.ds?.scale || 1) <= 0.5;
-        if (!lowQuality) {
-          // Clicked on right half with nav arrow, go to the group, center on group and set
-          // zoom to see it all.
-          canvas.centerOnNode(this.group);
-          const zoomCurrent = canvas.ds?.scale || 1;
-          const zoomX = canvas.canvas.width / this.group._size[0] - 0.02;
-          const zoomY = canvas.canvas.height / this.group._size[1] - 0.02;
-          canvas.setZoom(Math.min(zoomCurrent, zoomX, zoomY), [
-            canvas.canvas.width / 2,
-            canvas.canvas.height / 2,
-          ]);
-          canvas.setDirty(true, true);
-        }
-      } else {
-        this.toggle();
-      }
+  /** Start a drag-to-reorder. Returning true claims the pointer so move/up are delivered. */
+  private onDragDown = (event: CanvasMouseEvent, pos: Vector2, node: LGraphNode): boolean => {
+    const rows = this.node.getRowWidgets();
+    this.dragStartIndex = rows.indexOf(this);
+    if (this.dragStartIndex < 0) {
+      return false;
     }
+    this.dragging = true;
+    this.dragStartY = pos[1];
+    this.node.dragWidget = this;
+    this.node.dragDropIndex = this.dragStartIndex;
+    this.node.setDirtyCanvas(true, false);
     return true;
-  }
+  };
+
+  /** While dragging, translate vertical movement into a target drop index. */
+  private onDragMove = (event: CanvasMouseEvent, pos: Vector2, node: LGraphNode): void => {
+    if (!this.dragging) {
+      return;
+    }
+    const rows = this.node.getRowWidgets();
+    const slot = LiteGraph.NODE_WIDGET_HEIGHT + 4;
+    // pos[1] is node-local Y (relative to this widget's top), so the delta from where the drag
+    // began, divided by the per-row height, is how many slots we've moved.
+    const movedSlots = Math.round((pos[1] - this.dragStartY) / slot);
+    let idx = this.dragStartIndex + movedSlots;
+    idx = Math.max(0, Math.min(rows.length - 1, idx));
+    if (idx !== this.node.dragDropIndex) {
+      this.node.dragDropIndex = idx;
+      this.node.setDirtyCanvas(true, false);
+    }
+  };
+
+  /** Finish the drag: commit the new order (which engages "manual" sort and persists it). */
+  private onDragUp = (event: CanvasMouseEvent, pos: Vector2, node: LGraphNode): boolean => {
+    if (!this.dragging) {
+      return false;
+    }
+    const target = this.node.dragDropIndex;
+    const from = this.dragStartIndex;
+    this.dragging = false;
+    this.dragStartIndex = -1;
+    this.node.dragWidget = null;
+    this.node.dragDropIndex = -1;
+    this.node.commitManualOrder(from, target);
+    return true;
+  };
+
+  private onToggleClick = (event: CanvasMouseEvent, pos: Vector2, node: LGraphNode): boolean => {
+    this.toggle();
+    return true;
+  };
+
+  private onNavClick = (event: CanvasMouseEvent, pos: Vector2, node: LGraphNode): boolean => {
+    if (node.properties?.[PROPERTY_SHOW_NAV] === false) {
+      return false;
+    }
+    const canvas = app.canvas as TLGraphCanvas;
+    const lowQuality = (canvas.ds?.scale || 1) <= 0.5;
+    if (lowQuality) {
+      return false;
+    }
+    // Center on the group and zoom to fit it.
+    canvas.centerOnNode(this.group);
+    const zoomCurrent = canvas.ds?.scale || 1;
+    const zoomX = canvas.canvas.width / this.group._size[0] - 0.02;
+    const zoomY = canvas.canvas.height / this.group._size[1] - 0.02;
+    canvas.setZoom(Math.min(zoomCurrent, zoomX, zoomY), [
+      canvas.canvas.width / 2,
+      canvas.canvas.height / 2,
+    ]);
+    canvas.setDirty(true, true);
+    return true;
+  };
 }
 
 app.registerExtension({

--- a/web/comfyui/fast_groups_muter.js
+++ b/web/comfyui/fast_groups_muter.js
@@ -12,6 +12,8 @@ const PROPERTY_MATCH_TITLE = "matchTitle";
 const PROPERTY_SHOW_NAV = "showNav";
 const PROPERTY_SHOW_ALL_GRAPHS = "showAllGraphs";
 const PROPERTY_RESTRICTION = "toggleRestriction";
+const PROPERTY_MANUAL_ORDER = "manualOrder";
+const SORT_MANUAL = "manual";
 export class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
     constructor(title = FastGroupsMuter.title) {
         super(title);
@@ -28,6 +30,9 @@ export class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
         this.properties[PROPERTY_SORT] = "position";
         this.properties[PROPERTY_SORT_CUSTOM_ALPHA] = "";
         this.properties[PROPERTY_RESTRICTION] = "default";
+        this.properties[PROPERTY_MANUAL_ORDER] = [];
+        this.dragWidget = null;
+        this.dragDropIndex = -1;
     }
     onConstructed() {
         this.addOutput("OPT_CONNECTION", "*");
@@ -84,6 +89,19 @@ export class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
                     return 1;
                 }
                 return a.title.localeCompare(b.title);
+            });
+        }
+        if (sort === SORT_MANUAL) {
+            const order = (this.properties === null || this.properties === void 0 ? void 0 : this.properties[PROPERTY_MANUAL_ORDER]) || [];
+            const rank = new Map();
+            order.forEach((title, i) => rank.set(title, i));
+            groups.sort((a, b) => {
+                const ai = rank.has(a.title) ? rank.get(a.title) : Number.MAX_SAFE_INTEGER;
+                const bi = rank.has(b.title) ? rank.get(b.title) : Number.MAX_SAFE_INTEGER;
+                if (ai === bi) {
+                    return 0;
+                }
+                return ai - bi;
             });
         }
         let filterColors = (((_e = (_d = this.properties) === null || _d === void 0 ? void 0 : _d[PROPERTY_MATCH_COLORS]) === null || _e === void 0 ? void 0 : _e.split(",")) || []).filter((c) => c.trim());
@@ -178,6 +196,27 @@ export class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
         }, 16);
         return size;
     }
+    getRowWidgets() {
+        return (this.widgets || []).filter((w) => w instanceof FastGroupsToggleRowWidget);
+    }
+    commitManualOrder(from, to) {
+        const rows = this.getRowWidgets();
+        to = Math.max(0, Math.min(rows.length - 1, to));
+        if (from < 0 || from >= rows.length || from === to) {
+            this.setDirtyCanvas(true, false);
+            return;
+        }
+        rows.splice(to, 0, rows.splice(from, 1)[0]);
+        let r = 0;
+        for (let i = 0; i < this.widgets.length; i++) {
+            if (this.widgets[i] instanceof FastGroupsToggleRowWidget) {
+                this.widgets[i] = rows[r++];
+            }
+        }
+        this.properties[PROPERTY_SORT] = SORT_MANUAL;
+        this.properties[PROPERTY_MANUAL_ORDER] = rows.map((w) => w.group.title);
+        this.setDirtyCanvas(true, true);
+    }
     async handleAction(action) {
         var _a, _b, _c, _d, _e;
         if (action === "Mute all" || action === "Bypass all") {
@@ -235,7 +274,14 @@ export class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
             </p></li>
             <li><p>
               <code>${PROPERTY_SORT}</code> - Sort the toggles' order by "alphanumeric", graph
-              "position", or "custom alphabet". <i>(default: "position")</i>
+              "position", "custom alphabet", or "manual". <i>(default: "position")</i>
+            </p>
+            <p>
+              <strong>Manual drag ordering:</strong> drag any row by its label (the left part of
+              the row, away from the toggle and nav arrow) and drop it in a new position. The first
+              drag automatically switches <code>${PROPERTY_SORT}</code> to "manual", and the order
+              is saved with your workflow. Newly-added groups appear at the end until you place
+              them.
             </p></li>
             <li>
               <p>
@@ -285,9 +331,10 @@ BaseFastGroupsModeChanger["@showNav"] = { type: "boolean" };
 BaseFastGroupsModeChanger["@showAllGraphs"] = { type: "boolean" };
 BaseFastGroupsModeChanger["@sort"] = {
     type: "combo",
-    values: ["position", "alphanumeric", "custom alphabet"],
+    values: ["position", "alphanumeric", "custom alphabet", "manual"],
 };
 BaseFastGroupsModeChanger["@customSortAlphabet"] = { type: "string" };
+BaseFastGroupsModeChanger["@manualOrder"] = { type: "array" };
 BaseFastGroupsModeChanger["@toggleRestriction"] = {
     type: "combo",
     values: ["default", "max one", "always one"],
@@ -314,6 +361,14 @@ class FastGroupsToggleRowWidget extends RgthreeBaseWidget {
         this.label = "";
         this.group = group;
         this.node = node;
+        this.dragging = false;
+        this.dragStartY = 0;
+        this.dragStartIndex = -1;
+        this.hitAreas = {
+            drag: { bounds: [0, 0], onDown: this.onDragDown, onMove: this.onDragMove, onUp: this.onDragUp },
+            toggle: { bounds: [0, 0], onClick: this.onToggleClick },
+            nav: { bounds: [0, 0], onClick: this.onNavClick },
+        };
     }
     doModeChange(force, skipOtherNodeCheck) {
         var _a, _b, _c, _d;
@@ -352,8 +407,21 @@ class FastGroupsToggleRowWidget extends RgthreeBaseWidget {
     }
     draw(ctx, node, width, posY, height) {
         var _a;
+        const fastNode = node;
+        const isDragging = fastNode.dragWidget === this;
+        if (isDragging) {
+            ctx.save();
+            ctx.globalAlpha = 0.4;
+        }
         const widgetData = drawNodeWidget(ctx, { size: [width, height], pos: [15, posY] });
         const showNav = ((_a = node.properties) === null || _a === void 0 ? void 0 : _a[PROPERTY_SHOW_NAV]) !== false;
+        const navWidth = 28 + 1;
+        const navStart = width - 15 - navWidth;
+        const toggleWidth = 90;
+        const toggleStart = navStart - toggleWidth;
+        this.hitAreas.nav.bounds = showNav ? [navStart, navWidth] : [width, 0];
+        this.hitAreas.toggle.bounds = [toggleStart, showNav ? toggleWidth : toggleWidth + navWidth];
+        this.hitAreas.drag.bounds = [15, Math.max(0, toggleStart - 15)];
         let currentX = widgetData.width - widgetData.margin;
         if (!widgetData.lowQuality && showNav) {
             currentX -= 7;
@@ -391,36 +459,105 @@ class FastGroupsToggleRowWidget extends RgthreeBaseWidget {
             currentX -= 7;
             ctx.textAlign = "left";
             let maxLabelWidth = widgetData.width - widgetData.margin - 10 - (widgetData.width - currentX);
+            const labelX = widgetData.margin + 10 + 10;
             if (label != null) {
-                ctx.fillText(fitString(ctx, label, maxLabelWidth), widgetData.margin + 10, posY + height * 0.7);
+                ctx.fillText(fitString(ctx, label, maxLabelWidth - 10), labelX, posY + height * 0.7);
+            }
+            const gripX = widgetData.margin + 6;
+            const gripMidY = posY + height * 0.5;
+            ctx.fillStyle = widgetData.colorTextSecondary;
+            for (let i = -1; i <= 1; i++) {
+                ctx.beginPath();
+                ctx.arc(gripX, gripMidY + i * 4, 1.1, 0, Math.PI * 2);
+                ctx.fill();
+            }
+        }
+        if (isDragging) {
+            ctx.restore();
+        }
+        const fastNode2 = node;
+        if (fastNode2.dragWidget &&
+            fastNode2.dragWidget !== this &&
+            fastNode2.dragDropIndex > -1) {
+            const rows = (node.widgets || []).filter((w) => w instanceof FastGroupsToggleRowWidget);
+            if (rows[fastNode2.dragDropIndex] === this) {
+                ctx.save();
+                ctx.strokeStyle = "#89A";
+                ctx.lineWidth = 2;
+                ctx.beginPath();
+                ctx.moveTo(widgetData.margin, posY - 1);
+                ctx.lineTo(widgetData.width - widgetData.margin, posY - 1);
+                ctx.stroke();
+                ctx.restore();
             }
         }
     }
     serializeValue(node, index) {
         return this.value;
     }
-    mouse(event, pos, node) {
-        var _a, _b, _c;
-        if (event.type == "pointerdown") {
-            if (((_a = node.properties) === null || _a === void 0 ? void 0 : _a[PROPERTY_SHOW_NAV]) !== false && pos[0] >= node.size[0] - 15 - 28 - 1) {
-                const canvas = app.canvas;
-                const lowQuality = (((_b = canvas.ds) === null || _b === void 0 ? void 0 : _b.scale) || 1) <= 0.5;
-                if (!lowQuality) {
-                    canvas.centerOnNode(this.group);
-                    const zoomCurrent = ((_c = canvas.ds) === null || _c === void 0 ? void 0 : _c.scale) || 1;
-                    const zoomX = canvas.canvas.width / this.group._size[0] - 0.02;
-                    const zoomY = canvas.canvas.height / this.group._size[1] - 0.02;
-                    canvas.setZoom(Math.min(zoomCurrent, zoomX, zoomY), [
-                        canvas.canvas.width / 2,
-                        canvas.canvas.height / 2,
-                    ]);
-                    canvas.setDirty(true, true);
-                }
-            }
-            else {
-                this.toggle();
-            }
+    onDragDown(event, pos, node) {
+        const rows = this.node.getRowWidgets();
+        this.dragStartIndex = rows.indexOf(this);
+        if (this.dragStartIndex < 0) {
+            return false;
         }
+        this.dragging = true;
+        this.dragStartY = pos[1];
+        this.node.dragWidget = this;
+        this.node.dragDropIndex = this.dragStartIndex;
+        this.node.setDirtyCanvas(true, false);
+        return true;
+    }
+    onDragMove(event, pos, node) {
+        if (!this.dragging) {
+            return;
+        }
+        const rows = this.node.getRowWidgets();
+        const slot = LiteGraph.NODE_WIDGET_HEIGHT + 4;
+        const movedSlots = Math.round((pos[1] - this.dragStartY) / slot);
+        let idx = this.dragStartIndex + movedSlots;
+        idx = Math.max(0, Math.min(rows.length - 1, idx));
+        if (idx !== this.node.dragDropIndex) {
+            this.node.dragDropIndex = idx;
+            this.node.setDirtyCanvas(true, false);
+        }
+    }
+    onDragUp(event, pos, node) {
+        if (!this.dragging) {
+            return false;
+        }
+        const target = this.node.dragDropIndex;
+        const from = this.dragStartIndex;
+        this.dragging = false;
+        this.dragStartIndex = -1;
+        this.node.dragWidget = null;
+        this.node.dragDropIndex = -1;
+        this.node.commitManualOrder(from, target);
+        return true;
+    }
+    onToggleClick(event, pos, node) {
+        this.toggle();
+        return true;
+    }
+    onNavClick(event, pos, node) {
+        var _a, _b;
+        if (((_a = node.properties) === null || _a === void 0 ? void 0 : _a[PROPERTY_SHOW_NAV]) === false) {
+            return false;
+        }
+        const canvas = app.canvas;
+        const lowQuality = (((_b = canvas.ds) === null || _b === void 0 ? void 0 : _b.scale) || 1) <= 0.5;
+        if (lowQuality) {
+            return false;
+        }
+        canvas.centerOnNode(this.group);
+        const zoomCurrent = canvas.ds && canvas.ds.scale ? canvas.ds.scale : 1;
+        const zoomX = canvas.canvas.width / this.group._size[0] - 0.02;
+        const zoomY = canvas.canvas.height / this.group._size[1] - 0.02;
+        canvas.setZoom(Math.min(zoomCurrent, zoomX, zoomY), [
+            canvas.canvas.width / 2,
+            canvas.canvas.height / 2,
+        ]);
+        canvas.setDirty(true, true);
         return true;
     }
 }


### PR DESCRIPTION
Added drag-and-drop reordering to the Fast Groups Bypasser and Muter, since both share a base class. All changes live in fast_groups_muter.ts/.js, where BaseFastGroupsModeChanger defines how group toggles are built, sorted, and drawn. 

The feature works by adding a new "manual" sort mode alongside the existing position/alphanumeric/custom-alphabet modes: dragging any row by its label auto-switches the node into manual mode, captures the new order into a serialized manualOrder property, and re-applies that order on every widget refresh. 

https://github.com/user-attachments/assets/81e72952-57ff-402d-b488-8425374d66f6