### PR TITLE
fix: normalize fast groups muter widget size

### DIFF
--- a/web/comfyui/fast_groups_muter.js
+++ b/web/comfyui/fast_groups_muter.js
@@ -21,6 +21,7 @@ export class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
         this.tempSize = null;
         this.serialize_widgets = false;
         this.helpActions = "mute and unmute";
+        this.debouncerNormalizeSize = 0;
         this.properties[PROPERTY_MATCH_COLORS] = "";
         this.properties[PROPERTY_MATCH_TITLE] = "";
         this.properties[PROPERTY_SHOW_NAV] = true;
@@ -170,6 +171,15 @@ export class BaseFastGroupsModeChanger extends RgthreeBaseVirtualNode {
             this.debouncerTempWidth && clearTimeout(this.debouncerTempWidth);
             this.debouncerTempWidth = setTimeout(() => {
                 this.tempSize = null;
+                this.debouncerNormalizeSize && clearTimeout(this.debouncerNormalizeSize);
+                this.debouncerNormalizeSize = setTimeout(() => {
+                    var _a;
+                    const normalizedSize = super.computeSize(out);
+                    if (normalizedSize[0] !== this.size[0] || normalizedSize[1] !== this.size[1]) {
+                        this.setSize(normalizedSize);
+                    }
+                    (_a = this.graph) === null || _a === void 0 ? void 0 : _a.setDirtyCanvas(true, true);
+                }, 0);
             }, 32);
         }
         setTimeout(() => {


### PR DESCRIPTION
## Summary

This fixes a transient sizing issue in `Fast Groups Muter` where the widget row width can be inconsistent after refresh / load, causing the first row to render with an incorrect length.

## Tested environment

- ComfyUI core: `v0.24.0`
- ComfyUI commit: `f49bdb65`
- comfyui-frontend-package: `1.44.19`

Validated on the classic / non-Vue node path.

## Problem

`Fast Groups Muter` uses a temporary size (`tempSize`) while widgets are being refreshed.

After that temporary sizing window ends, the node can keep a stale width for one render phase, which makes widget row drawing inconsistent even though the final computed size should be smaller / normalized.

## Changes

- add a follow-up normalization step after the temporary sizing debounce clears
- recompute the final node size with `super.computeSize(...)`
- call `setSize(...)` if the current node size no longer matches the normalized size
- mark the canvas dirty so the corrected layout is redrawn immediately

## Why this helps

This preserves the existing temporary sizing behavior during refresh, but ensures the node settles back to its real computed size once the refresh is complete.

## Manual validation

Validated manually with a workflow containing `Fast Groups Muter` where the first widget row previously rendered with inconsistent width/length.
After this change, widget row widths are consistent after load/refresh.