### PR TITLE
Do not re-run image comparer if inputs have not changed

### DIFF
--- a/py/image_comparer.py
+++ b/py/image_comparer.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from nodes import PreviewImage
 
 from .constants import get_category, get_name
@@ -24,6 +26,15 @@ class RgthreeImageComparer(PreviewImage):
         "extra_pnginfo": "EXTRA_PNGINFO"
       },
     }
+
+  @classmethod
+  def IS_CHANGED(cls, image_a=None, image_b=None, **kwargs):
+    m = hashlib.sha256()
+    if image_a is not None:
+      m.update(image_a.cpu().numpy().tobytes())
+    if image_b is not None:
+      m.update(image_b.cpu().numpy().tobytes())
+    return m.hexdigest()
 
   def compare_images(self,
                      image_a=None,


### PR DESCRIPTION
Very quick and small fix to let the image comparer step aside if the inputs have not changed. This avoids frontend redownloading/rendering of unchanged data (most noticeable on mobile, at least for me)