### PR TITLE
Fix progress bar context menu title showing raw HTML on newer frontends

### DIFF
--- a/src_web/comfyui/rgthree.ts
+++ b/src_web/comfyui/rgthree.ts
@@ -320,11 +320,18 @@ class Rgthree extends EventTarget {
           LiteGraph.closeAllContextMenus();
           if (e.button == 2) {
             const canvas = await waitForCanvas();
-            new LiteGraph.ContextMenu(this.getRgthreeIContextMenuValues(), {
-              title: `<div class="rgthree-contextmenu-item rgthree-contextmenu-title-rgthree-comfy">${logoRgthree} rgthree-comfy</div>`,
+            // Newer ComfyUI frontends render the ContextMenu title with textContent (no HTML
+            // parsing), which would show an HTML title as raw markup. Pass a plain-text title,
+            // then swap in our logo markup afterwards.
+            const menu = new LiteGraph.ContextMenu(this.getRgthreeIContextMenuValues(), {
+              title: "rgthree-comfy",
               left: e.clientX,
               top: 5,
             });
+            const titleEl = query<HTMLDivElement>(".litemenu-title", menu.root);
+            if (titleEl) {
+              titleEl.innerHTML = `<div class="rgthree-contextmenu-item rgthree-contextmenu-title-rgthree-comfy">${logoRgthree} rgthree-comfy</div>`;
+            }
             return;
           }
           if (e.button == 0) {

--- a/web/comfyui/rgthree.js
+++ b/web/comfyui/rgthree.js
@@ -188,11 +188,15 @@ class Rgthree extends EventTarget {
                     LiteGraph.closeAllContextMenus();
                     if (e.button == 2) {
                         const canvas = await waitForCanvas();
-                        new LiteGraph.ContextMenu(this.getRgthreeIContextMenuValues(), {
-                            title: `<div class="rgthree-contextmenu-item rgthree-contextmenu-title-rgthree-comfy">${logoRgthree} rgthree-comfy</div>`,
+                        const menu = new LiteGraph.ContextMenu(this.getRgthreeIContextMenuValues(), {
+                            title: "rgthree-comfy",
                             left: e.clientX,
                             top: 5,
                         });
+                        const titleEl = query(".litemenu-title", menu.root);
+                        if (titleEl) {
+                            titleEl.innerHTML = `<div class="rgthree-contextmenu-item rgthree-contextmenu-title-rgthree-comfy">${logoRgthree} rgthree-comfy</div>`;
+                        }
                         return;
                     }
                     if (e.button == 0) {


### PR DESCRIPTION
Fixes #744

## Problem

Right-clicking the rgthree progress bar opens the rgthree-comfy context menu, but on newer ComfyUI frontends the menu title is displayed as raw HTML/SVG markup instead of the rendered logo:

![Context menu title showing raw HTML markup](https://raw.githubusercontent.com/hcwhan/rgthree-comfy/issue-assets/contextmenu-title-raw-html.png)

The frontend's LiteGraph `ContextMenu` now renders `options.title` with `textContent` (part of the XSS hardening that also sanitizes item content through DOMPurify), so the HTML string passed as `title` is no longer parsed:

```ts
// ComfyUI_frontend src/lib/litegraph/src/ContextMenu.ts
if (options.title) {
  const element = document.createElement('div')
  element.className = 'litemenu-title'
  element.textContent = options.title
  root.append(element)
}
```

Observed with `comfyui-frontend-package` 1.45.20, rgthree-comfy 27b4f4c (current main).

## Fix

Pass a plain-text `title` ("rgthree-comfy"), then swap in the logo markup on the created `.litemenu-title` element after the menu is constructed. Since we control `menu.root`, this keeps the exact same DOM structure and styling (`.rgthree-contextmenu-title-rgthree-comfy`) as before, and behaves identically on older frontends that still rendered the title via `innerHTML`.

Both `src_web/comfyui/rgthree.ts` and the compiled `web/comfyui/rgthree.js` are updated (compiled output edited to match, to avoid unrelated churn from a full rebuild with a newer tsc).
